### PR TITLE
Stop double counting enqueueing stats

### DIFF
--- a/lib/active_job/stats/callbacks.rb
+++ b/lib/active_job/stats/callbacks.rb
@@ -3,7 +3,6 @@ module ActiveJob
     module Callbacks
       extend ActiveSupport::Concern
       included do
-        before_enqueue :after_enqueue_stats,  if: :monitored
         after_enqueue  :after_enqueue_stats,  if: :monitored
         before_perform :before_perform_stats, if: :monitored
         after_perform  :after_perform_stats,  if: :monitored


### PR DESCRIPTION
I was browsing the code base and saw this was called before and after enqueueing. I haven't tested it but it seems like it would cause double the counts.

Want a test to go with it?
