### PR TITLE
Allow inheritance of `monitored` and `benchmarked`

### DIFF
--- a/lib/active_job/stats/options.rb
+++ b/lib/active_job/stats/options.rb
@@ -1,15 +1,15 @@
 module ActiveJob
   module Stats
     module Options
-      attr_reader(:monitored)
-      attr_reader(:benchmarked)
+      cattr_reader(:monitored)
+      cattr_reader(:benchmarked)
 
       def benchmark(benchmarked=true)
-        @benchmarked = benchmarked
+        @@benchmarked = benchmarked
       end
 
       def monitor(monitored=true)
-        @monitored = monitored
+        @@monitored = monitored
       end
 
     end


### PR DESCRIPTION
We like to establish a high level `ApplicationJob` in our apps that actual work-processing jobs can inherit from. To enable that, this pull request switches to using a `cattr_reader` to handle tracking of benchmark & monitor status so that we can declare those once on the `ApplicationJob`.

(tests fail both on master and on this PR, but we're using this on a real app with results as expected)