### PR TITLE
fix:dev: Use job instance's queue_name instead of class's

### DIFF
--- a/lib/active_job/stats/callbacks.rb
+++ b/lib/active_job/stats/callbacks.rb
@@ -15,24 +15,24 @@ module ActiveJob
         def benchmark_stats
           require 'active_support/core_ext/benchmark'
           benchmark = Benchmark.ms { yield }
-          ActiveJob::Stats.reporter.timing("#{self.class.queue_name}.processed", benchmark)
+          ActiveJob::Stats.reporter.timing("#{queue_name}.processed", benchmark)
           ActiveJob::Stats.reporter.timing("#{self.class}.processed", benchmark)
         end
 
         def before_perform_stats
-          ActiveJob::Stats.reporter.increment("#{self.class.queue_name}.started")
+          ActiveJob::Stats.reporter.increment("#{queue_name}.started")
           ActiveJob::Stats.reporter.increment("#{self.class}.started")
           ActiveJob::Stats.reporter.increment('total.started')
         end
 
         def after_enqueue_stats
-          ActiveJob::Stats.reporter.increment("#{self.class.queue_name}.enqueued")
+          ActiveJob::Stats.reporter.increment("#{queue_name}.enqueued")
           ActiveJob::Stats.reporter.increment("#{self.class}.enqueued")
           ActiveJob::Stats.reporter.increment('total.enqueued')
         end
 
         def after_perform_stats
-          ActiveJob::Stats.reporter.increment("#{self.class.queue_name}.finished")
+          ActiveJob::Stats.reporter.increment("#{queue_name}.finished")
           ActiveJob::Stats.reporter.increment("#{self.class}.finished")
           ActiveJob::Stats.reporter.increment('total.finished')
         end


### PR DESCRIPTION
Two good reasons:
- The job instance can be enqueued with a different queue_name than its
class normally has.
- The job class can pass a Proc to queue_as to dynamically determine
the name. The queue_name is still set on the job instance.